### PR TITLE
Redirect readers of awc-explainer.md to README.md

### DIFF
--- a/awc-explainer.md
+++ b/awc-explainer.md
@@ -1,0 +1,1 @@
+# Moved to [README.md](README.md)

--- a/index.bs
+++ b/index.bs
@@ -20,7 +20,7 @@ Include Can I Use Panels: yes
 Introduction {#intro}
 =====================
 
-For now, see the [explainer]([README.md]).
+For now, see the [explainer](README.md).
 
 See [https://garykac.github.io/procspec/](https://garykac.github.io/procspec/),
 [https://dlaliberte.github.io/bikeshed-intro/index.html](https://dlaliberte.github.io/bikeshed-intro/index.html),


### PR DESCRIPTION
Many links in chromium code and docs refers to the previous name of the README, i.e. awc-explainer.md. This commit prevents breaking them.